### PR TITLE
Fix CTA Button Outline

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -96,8 +96,6 @@ button.button {
   }
 
   &:focus {
-    outline-style: solid;
-    outline-color: transparent;
     box-shadow: 0 0 0 6px scale-color($btnColor, $lightness: -40%);
   }
 


### PR DESCRIPTION
# Description

With this merge, the black outline that was apparent on Call To Action buttons will be removed.

Turns out that Outline was set on focus combined with internal box-shadow. Now, just box-shadow will remain visible.